### PR TITLE
修复【发起批量转账API】，转账姓名为空是发生NPE

### DIFF
--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatBatchTransferApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatBatchTransferApi.java
@@ -82,8 +82,10 @@ public class WechatBatchTransferApi extends AbstractApi {
         List<CreateBatchTransferParams.TransferDetailListItem> encrypted = transferDetailList.stream()
                 .peek(transferDetailListItem -> {
                     String userName = transferDetailListItem.getUserName();
-                    String encryptedUserName = signatureProvider.encryptRequestMessage(userName, x509Certificate);
-                    transferDetailListItem.setUserName(encryptedUserName);
+                    if(StringUtils.hasText(userName)){
+                        String encryptedUserName = signatureProvider.encryptRequestMessage(userName, x509Certificate);
+                        transferDetailListItem.setUserName(encryptedUserName);
+                    }
                     String userIdCard = transferDetailListItem.getUserIdCard();
                     if (StringUtils.hasText(userIdCard)) {
                         String encryptedUserIdCard = signatureProvider.encryptRequestMessage(userIdCard, x509Certificate);


### PR DESCRIPTION
当付款金额低于0.3元的时候，微信不支持实名验证，因此不能传userName。
不传userName，此处为发生NPE。