### PR TITLE
1.0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 - `WechatSmartGuideApi` 服务商或者直连商户-经营能力-支付即服务
 - `WechatGoldPlanApi` 服务商-经营能力-点金计划
 
-> 随着版本迭代功能会增加。
+> 随着版本迭代功能会增加，可通过API注册表类`WechatPayV3Type`进行API接口检索。
 
 ## 开源协议
 **Apache 2.0**

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Maven Central Repo Deployment](https://github.com/NotFound403/payment-spring-boot/actions/workflows/main.yml/badge.svg)](https://github.com/NotFound403/payment-spring-boot/actions/workflows/main.yml)
 
-# 最好用的微信支付V3 Spring Boot 组件
+# 最全最好用的微信支付V3 Spring Boot 组件
 
-为了满足业务中出现app支付、公众号支付、小程序支付等多appid并存的场景，对原有的进行了增强开发出了多租户版本。
+微信支付V3支付，支持微信优惠券，代金券、商家券、智慧商圈、商家转账到零钱、公众号支付、微信小程序支付、分账、支付分、商家券、合单支付、先享卡、电商收付通等全部微信支付功能API，同时满足多个服务商、多个商户开发需求。一键集成，API友好，上手快，欢迎star。
 
 请给[Payment Spring Boot](https://github.com/NotFound403/payment-spring-boot) **Star**以鼓励，谢谢。
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/PayException.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/PayException.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/alipay/AliPayConfiguration.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/alipay/AliPayConfiguration.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.alipay;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/alipay/AliPayProperties.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/alipay/AliPayProperties.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.alipay;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/autoconfigure/EnableMobilePay.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/autoconfigure/EnableMobilePay.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.autoconfigure;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/autoconfigure/PayConfiguration.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/autoconfigure/PayConfiguration.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.autoconfigure;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/autoconfigure/PayConfiguration.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/autoconfigure/PayConfiguration.java
@@ -18,6 +18,7 @@ package cn.felord.payment.autoconfigure;
 
 import cn.felord.payment.alipay.AliPayConfiguration;
 import cn.felord.payment.wechat.WechatPayConfiguration;
+import cn.felord.payment.wechat.WechatTenantServiceConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
@@ -26,6 +27,6 @@ import org.springframework.context.annotation.Import;
  * @since 1.0.0.RELEASE
  */
 @Configuration
-@Import({WechatPayConfiguration.class, AliPayConfiguration.class})
+@Import({WechatPayConfiguration.class, WechatTenantServiceConfiguration.class, AliPayConfiguration.class})
 public class PayConfiguration {
 }

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/InMemoryWechatTenantService.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/InMemoryWechatTenantService.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cn.felord.payment.wechat;
+
+import cn.felord.payment.wechat.v3.KeyPairFactory;
+import cn.felord.payment.wechat.v3.WechatMetaBean;
+import lombok.AllArgsConstructor;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author xiafang
+ * @since 2023/2/3 11:40
+ */
+@AllArgsConstructor
+public class InMemoryWechatTenantService implements WechatTenantService {
+    private final WechatPayProperties wechatPayProperties;
+
+    @Override
+    public Set<WechatMetaBean> getAllTenants() {
+        Map<String, WechatPayProperties.V3> v3Map = wechatPayProperties.getV3();
+        KeyPairFactory keyPairFactory = new KeyPairFactory();
+        return v3Map.entrySet()
+                .stream()
+                .map(entry -> {
+                    WechatPayProperties.V3 v3 = entry.getValue();
+                    String tenantId = entry.getKey();
+                    String certPath = v3.getCertPath();
+                    String certAbsolutePath = v3.getCertAbsolutePath();
+                    String mchId = v3.getMchId();
+                    Resource resource = certAbsolutePath != null ? new FileSystemResource(certAbsolutePath) :
+                            new ClassPathResource(certPath == null ? "wechat/apiclient_cert.p12" : certPath);
+                    WechatMetaBean wechatMetaBean = keyPairFactory.initWechatMetaBean(resource, mchId);
+                    wechatMetaBean.setV3(v3);
+                    wechatMetaBean.setTenantId(tenantId);
+                    return wechatMetaBean;
+                })
+                .collect(Collectors.toSet());
+    }
+}

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/InMemoryWechatTenantService.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/InMemoryWechatTenantService.java
@@ -29,6 +29,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
+ * 从配置文件中加载租户信息,默认实现,可被覆盖
+ *
  * @author xiafang
  * @since 2023/2/3 11:40
  */
@@ -37,7 +39,7 @@ public class InMemoryWechatTenantService implements WechatTenantService {
     private final WechatPayProperties wechatPayProperties;
 
     @Override
-    public Set<WechatMetaBean> getAllTenants() {
+    public Set<WechatMetaBean> loadTenants() {
         Map<String, WechatPayProperties.V3> v3Map = wechatPayProperties.getV3();
         KeyPairFactory keyPairFactory = new KeyPairFactory();
         return v3Map.entrySet()

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatPayConfiguration.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatPayConfiguration.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatPayConfiguration.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatPayConfiguration.java
@@ -44,7 +44,7 @@ public class WechatPayConfiguration {
     @ConditionalOnMissingBean
     WechatMetaContainer wechatMetaContainer(WechatTenantService wechatTenantService) {
         WechatMetaContainer container = new WechatMetaContainer();
-              container.addWechatMetas(wechatTenantService.getAllTenants());
+              container.addWechatMetas(wechatTenantService.loadTenants());
         return container;
     }
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatPayConfiguration.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatPayConfiguration.java
@@ -17,17 +17,13 @@
 package cn.felord.payment.wechat;
 
 
-import cn.felord.payment.wechat.v3.*;
+import cn.felord.payment.wechat.v3.SignatureProvider;
+import cn.felord.payment.wechat.v3.WechatApiProvider;
+import cn.felord.payment.wechat.v3.WechatMetaContainer;
+import cn.felord.payment.wechat.v3.WechatPayClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
-
-import java.util.Map;
 
 /**
  * The type Wechat pay configuration.
@@ -36,39 +32,19 @@ import java.util.Map;
  * @since 1.0.0.RELEASE
  */
 @Configuration(proxyBeanMethods = false)
-@Conditional(WechatPayConfiguredCondition.class)
-@EnableConfigurationProperties(WechatPayProperties.class)
 public class WechatPayConfiguration {
-    /**
-     * The constant CERT_ALIAS.
-     */
-    private static final String CERT_ALIAS = "Tenpay Certificate";
 
     /**
      * 微信支付公私钥 以及序列号等元数据.
      *
-     * @param wechatPayProperties the wechat pay properties
+     * @param wechatTenantService the wechat tenant service
      * @return the wechat cert bean
      */
     @Bean
     @ConditionalOnMissingBean
-    WechatMetaContainer wechatMetaContainer(WechatPayProperties wechatPayProperties) {
-
-        Map<String, WechatPayProperties.V3> v3Map = wechatPayProperties.getV3();
+    WechatMetaContainer wechatMetaContainer(WechatTenantService wechatTenantService) {
         WechatMetaContainer container = new WechatMetaContainer();
-        KeyPairFactory keyPairFactory = new KeyPairFactory();
-        v3Map.keySet().forEach(tenantId -> {
-            WechatPayProperties.V3 v3 = v3Map.get(tenantId);
-            String certPath = v3.getCertPath();
-            String certAbsolutePath = v3.getCertAbsolutePath();
-            String mchId = v3.getMchId();
-            Resource resource = certAbsolutePath != null ? new FileSystemResource(certAbsolutePath) :
-                    new ClassPathResource(certPath == null ? "wechat/apiclient_cert.p12" : certPath);
-            WechatMetaBean wechatMetaBean = keyPairFactory.initWechatMetaBean(resource, CERT_ALIAS, mchId);
-            wechatMetaBean.setV3(v3);
-            wechatMetaBean.setTenantId(tenantId);
-            container.addWechatMeta(tenantId, wechatMetaBean);
-        });
+              container.addWechatMetas(wechatTenantService.getAllTenants());
         return container;
     }
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatPayConfiguredCondition.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatPayConfiguredCondition.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatPayProperties.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatPayProperties.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatPayResponseErrorHandler.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatPayResponseErrorHandler.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatTenantService.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatTenantService.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cn.felord.payment.wechat;
+
+import cn.felord.payment.wechat.v3.WechatMetaBean;
+
+import java.util.Set;
+
+/**
+ * @author xiafang
+ * @since 2023/2/3 11:37
+ */
+public interface WechatTenantService {
+    Set<WechatMetaBean> getAllTenants();
+}

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatTenantService.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatTenantService.java
@@ -22,9 +22,12 @@ import cn.felord.payment.wechat.v3.WechatMetaBean;
 import java.util.Set;
 
 /**
- * @author xiafang
- * @since 2023/2/3 11:37
+ * 加载租户信息服务
+ *
+ * @author felord.cn
+ * @since 1.0.16.RELEASE
  */
+@FunctionalInterface
 public interface WechatTenantService {
-    Set<WechatMetaBean> getAllTenants();
+    Set<WechatMetaBean> loadTenants();
 }

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatTenantServiceConfiguration.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatTenantServiceConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cn.felord.payment.wechat;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * The type Wechat tenant service configuration.
+ *
+ * @author xiafang
+ * @since 2023 /2/3 12:32
+ */
+@Configuration(proxyBeanMethods = false)
+@Conditional(WechatPayConfiguredCondition.class)
+@EnableConfigurationProperties(WechatPayProperties.class)
+public class WechatTenantServiceConfiguration {
+
+    /**
+     * Wechat tenant service wechat tenant service.
+     *
+     * @param wechatPayProperties the wechat pay properties
+     * @return the wechat tenant service
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public WechatTenantService wechatTenantService(WechatPayProperties wechatPayProperties) {
+        return new InMemoryWechatTenantService(wechatPayProperties);
+    }
+}

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatTenantServiceConfiguration.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/WechatTenantServiceConfiguration.java
@@ -26,8 +26,8 @@ import org.springframework.context.annotation.Configuration;
 /**
  * The type Wechat tenant service configuration.
  *
- * @author xiafang
- * @since 2023 /2/3 12:32
+ * @author felord.cn
+ * @since 1.0.16.RELEASE
  */
 @Configuration(proxyBeanMethods = false)
 @Conditional(WechatPayConfiguredCondition.class)

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/BankCode.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/BankCode.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.enumeration;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/BusinessType.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/BusinessType.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cn.felord.payment.wechat.enumeration;
+
+/**
+ * The enum Business type.
+ *
+ * @author felord.cn
+ * @since 1.0.16.RELEASE
+ */
+public enum BusinessType {
+    /**
+     * 代金券批次（暂不支持合作方为商户的场景）
+     */
+    FAVOR_STOCK,
+    /**
+     * 商家券批次
+     */
+    BUSIFAVOR_STOCK
+}

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/ContractStatus.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/ContractStatus.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/CountType.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/CountType.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/CouponBgColor.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/CouponBgColor.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/CouponStatus.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/CouponStatus.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.enumeration;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/FundFlowAccountType.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/FundFlowAccountType.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/PartnerType.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/PartnerType.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cn.felord.payment.wechat.enumeration;
+
+/**
+ * The enum Partner type.
+ *
+ * @author felord.cn
+ * @since 1.0.16.RELEASE
+ */
+public enum PartnerType {
+    /**
+     * 合作方为APPID
+     */
+    APPID,
+    /**
+     * 合作方为商户
+     */
+    MERCHANT
+}

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/PartnershipState.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/PartnershipState.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cn.felord.payment.wechat.enumeration;
+
+/**
+ * 合作状态
+ *
+ * @author felord.cn
+ * @since 1.0.16.RELEASE
+ */
+public enum PartnershipState {
+    /**
+     * 已建立合作状态
+     */
+    ESTABLISHED,
+    /**
+     * 已终止合作状态
+     */
+    TERMINATED
+}

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/StockStatus.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/StockStatus.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.enumeration;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/StrategyType.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/StrategyType.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/TarType.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/TarType.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/TradeBillType.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/TradeBillType.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/TradeState.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/TradeState.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.enumeration;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/TradeType.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/TradeType.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.enumeration;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/UnfinishedReason.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/UnfinishedReason.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/WeChatServer.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/WeChatServer.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.enumeration;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/WechatPayAlgorithms.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/WechatPayAlgorithms.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cn.felord.payment.wechat.enumeration;
+
+import lombok.Getter;
+
+/**
+ * @author xiafang
+ * @since 2023/2/1 8:59
+ */
+@Getter
+public enum WechatPayAlgorithms {
+    RSA("WECHATPAY2-SHA256-RSA2048"),
+    SM3("WECHATPAY2-SM2-WITH-SM3");
+
+    private final String algorithm;
+
+    WechatPayAlgorithms(String algorithm) {
+        this.algorithm = algorithm;
+    }
+
+}

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/WechatPayV3Type.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/WechatPayV3Type.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.enumeration;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/WechatPayV3Type.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/enumeration/WechatPayV3Type.java
@@ -495,6 +495,20 @@ public enum WechatPayV3Type {
     MARKETING_BUSI_FAVOR_SUBSIDY_QUERY(HttpMethod.GET, "%s/v3/marketing/busifavor/subsidy/pay-receipts/{subsidy_receipt_id}"),
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     /**
+     * 建立合作关系API.
+     *
+     * @since 1.0.16.RELEASES
+     */
+    MARKETING_PARTNERSHIPS_BUILD(HttpMethod.POST, "%s/v3/marketing/partnerships/build"),
+    /**
+     * 查询合作关系列表API.
+     *
+     * @since 1.0.16.RELEASES
+     */
+    MARKETING_PARTNERSHIPS_GET(HttpMethod.GET, "%s/v3/marketing/partnerships"),
+
+    //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    /**
      * 发起批量转账API.
      *
      * @since 1.0.6.RELEASES

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/AbstractApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/AbstractApi.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/BranchBanksPageParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/BranchBanksPageParams.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package cn.felord.payment.wechat.v3;
 
 import cn.felord.payment.wechat.v3.model.PageParams;

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/ExtensionFormHttpMessageConverter.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/ExtensionFormHttpMessageConverter.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/KeyPairFactory.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/KeyPairFactory.java
@@ -18,11 +18,13 @@ package cn.felord.payment.wechat.v3;
 
 
 import cn.felord.payment.PayException;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 
-import java.security.*;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 
 /**
@@ -32,17 +34,20 @@ import java.security.cert.X509Certificate;
  * @since 1.0.0.RELEASE
  */
 public class KeyPairFactory {
-
+    private static final String CERT_ALIAS = "Tenpay Certificate";
     private static final KeyStore PKCS12_KEY_STORE;
 
-       static {
-           try {
-               PKCS12_KEY_STORE = KeyStore.getInstance("PKCS12");
-           } catch (KeyStoreException e) {
-             throw new PayException(" wechat pay keystore initialization failed");
-           }
-       }
+    static {
+        try {
+            PKCS12_KEY_STORE = KeyStore.getInstance("PKCS12");
+        } catch (KeyStoreException e) {
+            throw new PayException(" wechat pay keystore initialization failed");
+        }
+    }
 
+    public WechatMetaBean initWechatMetaBean(Resource resource, String keyPass) {
+        return this.initWechatMetaBean(resource, CERT_ALIAS, keyPass);
+    }
 
     /**
      * 获取公私钥.

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/KeyPairFactory.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/KeyPairFactory.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/SignatureProvider.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/SignatureProvider.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/SignatureProvider.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/SignatureProvider.java
@@ -187,7 +187,7 @@ public class SignatureProvider {
                     return CERTIFICATE_SET.stream()
                             .filter(cert -> Objects.equals(wechatpaySerial, cert.getWechatPaySerial()))
                             .findAny()
-                            .orElseThrow(()->new PayException("cannot obtain the certificate"));
+                            .orElseThrow(() -> new PayException("cannot obtain the certificate"));
                 });
 
 
@@ -235,8 +235,8 @@ public class SignatureProvider {
         }
         ArrayNode certificates = bodyObjectNode.withArray("data");
         if (certificates.isArray() && certificates.size() > 0) {
-            CERTIFICATE_SET.forEach( x509WechatCertificateInfo -> {
-                if (Objects.equals(tenantId,x509WechatCertificateInfo.getTenantId())){
+            CERTIFICATE_SET.forEach(x509WechatCertificateInfo -> {
+                if (Objects.equals(tenantId, x509WechatCertificateInfo.getTenantId())) {
                     CERTIFICATE_SET.remove(x509WechatCertificateInfo);
                 }
             });
@@ -257,7 +257,7 @@ public class SignatureProvider {
                     x509WechatCertificateInfo.setWechatPaySerial(responseSerialNo);
                     x509WechatCertificateInfo.setTenantId(tenantId);
                     x509WechatCertificateInfo.setX509Certificate((X509Certificate) certificate);
-                    CERTIFICATE_SET.add( x509WechatCertificateInfo);
+                    CERTIFICATE_SET.add(x509WechatCertificateInfo);
                 } catch (CertificateException e) {
                     throw new PayException("An error occurred while generating the wechat v3 certificate, reason : " + e.getMessage());
                 }
@@ -359,7 +359,7 @@ public class SignatureProvider {
      */
     public X509WechatCertificateInfo getCertificate(String tenantId) {
 
-      return CERTIFICATE_SET.stream()
+        return CERTIFICATE_SET.stream()
                 .filter(cert -> Objects.equals(tenantId, cert.getTenantId()))
                 .findAny()
                 .orElseGet(() -> {

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatApiProvider.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatApiProvider.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 
@@ -307,4 +305,13 @@ public class WechatApiProvider {
         return new WechatCapitalApi(wechatPayClient, tenantId);
     }
 
+    /**
+     * 风险合规-消费者投诉2.0
+     *
+     * @param tenantId the tenant id
+     * @return the wechat complaints api
+     */
+    public WechatComplaintsApi complaintsApi(String tenantId){
+        return new WechatComplaintsApi(wechatPayClient, tenantId);
+    }
 }

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatApiProvider.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatApiProvider.java
@@ -43,17 +43,6 @@ public class WechatApiProvider {
     }
 
     /**
-     * 代金券.
-     *
-     * @param tenantId the tenant id
-     * @return the wechat marketing favor api
-     * @since 1.0.0.RELEASE
-     */
-    public WechatMarketingFavorApi favorApi(String tenantId) {
-        return new WechatMarketingFavorApi(this.wechatPayClient, tenantId);
-    }
-
-    /**
      * 普通支付-直连模式.
      *
      * @param tenantId the tenant id
@@ -63,7 +52,6 @@ public class WechatApiProvider {
     public WechatDirectPayApi directPayApi(String tenantId) {
         return new WechatDirectPayApi(wechatPayClient, tenantId);
     }
-
 
     /**
      * 普通支付-服务商模式.
@@ -121,6 +109,17 @@ public class WechatApiProvider {
     }
 
     /**
+     * 代金券.
+     *
+     * @param tenantId the tenant id
+     * @return the wechat marketing favor api
+     * @since 1.0.0.RELEASE
+     */
+    public WechatMarketingFavorApi favorApi(String tenantId) {
+        return new WechatMarketingFavorApi(this.wechatPayClient, tenantId);
+    }
+
+    /**
      * 微信支付商家券.
      *
      * @param tenantId the tenant id
@@ -129,6 +128,16 @@ public class WechatApiProvider {
      */
     public WechatMarketingBusiFavorApi busiFavorApi(String tenantId) {
         return new WechatMarketingBusiFavorApi(wechatPayClient, tenantId);
+    }
+
+    /**
+     * 委托营销-直连商户
+     *
+     * @param tenantId the tenant id
+     * @return the wechat marketing partnership api
+     */
+    public WechatMarketingPartnershipApi marketingshipApi(String tenantId) {
+        return new WechatMarketingPartnershipApi(this.wechatPayClient, tenantId);
     }
 
     /**
@@ -198,7 +207,7 @@ public class WechatApiProvider {
     }
 
     /**
-     * 服务商微信支付分账，基于V3
+     * 服务商-微信支付分账，基于V3
      *
      * @param tenantId the tenant id
      * @return the wechat partner profitsharing api
@@ -208,7 +217,7 @@ public class WechatApiProvider {
     }
 
     /**
-     * 服务商品牌分账
+     * 服务商-品牌分账
      *
      * @param tenantId the tenant id
      * @return the wechat brand profitsharing api
@@ -262,7 +271,7 @@ public class WechatApiProvider {
     }
 
     /**
-     * 服务商智慧商圈
+     * 服务商-智慧商圈
      *
      * @param tenantId the tenant id
      * @return the wechat business circle api
@@ -273,7 +282,7 @@ public class WechatApiProvider {
     }
 
     /**
-     * 直连商户智慧商圈
+     * 直连商户-智慧商圈
      *
      * @param tenantId the tenant id
      * @return the wechat business circle api
@@ -311,7 +320,7 @@ public class WechatApiProvider {
      * @param tenantId the tenant id
      * @return the wechat complaints api
      */
-    public WechatComplaintsApi complaintsApi(String tenantId){
+    public WechatComplaintsApi complaintsApi(String tenantId) {
         return new WechatComplaintsApi(wechatPayClient, tenantId);
     }
 }

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatBrandProfitsharingApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatBrandProfitsharingApi.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package cn.felord.payment.wechat.v3;
 
 import cn.felord.payment.wechat.WechatPayProperties;

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatCapitalApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatCapitalApi.java
@@ -1,3 +1,20 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package cn.felord.payment.wechat.v3;
 
 import cn.felord.payment.wechat.enumeration.WeChatServer;

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatCombinePayApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatCombinePayApi.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatComplaintsApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatComplaintsApi.java
@@ -15,17 +15,22 @@
  *  limitations under the License.
  */
 
-package cn.felord.payment.wechat.v3.model.specmch;
-
-import java.util.List;
+package cn.felord.payment.wechat.v3;
 
 /**
+ * 风险合规-消费者投诉2.0
+ *
  * @author felord.cn
- * @since 1.0.14.RELEASE
+ * @since 1.0.16.RELEASE
  */
-public class AdditionInfo {
-    private String legalPersonCommitment;
-    private String legalPersonVideo;
-    private List<String> businessAdditionPics;
-    private String 	businessAdditionMsg;
+public class WechatComplaintsApi extends AbstractApi{
+    /**
+     * Instantiates a new Abstract api.
+     *
+     * @param wechatPayClient the wechat pay client
+     * @param tenantId        the tenant id
+     */
+    public WechatComplaintsApi(WechatPayClient wechatPayClient, String tenantId) {
+        super(wechatPayClient, tenantId);
+    }
 }

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatDirectPayApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatDirectPayApi.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatDiscountCardApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatDiscountCardApi.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMarketingBusiFavorApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMarketingBusiFavorApi.java
@@ -13,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMarketingFavorApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMarketingFavorApi.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMarketingPartnershipApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMarketingPartnershipApi.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright 2019-2023 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cn.felord.payment.wechat.v3;
+
+import cn.felord.payment.PayException;
+import cn.felord.payment.wechat.enumeration.WeChatServer;
+import cn.felord.payment.wechat.enumeration.WechatPayV3Type;
+import cn.felord.payment.wechat.v3.model.partnership.Partner;
+import cn.felord.payment.wechat.v3.model.partnership.PartnershipParams;
+import cn.felord.payment.wechat.v3.model.partnership.PartnershipQueryParams;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * 委托营销-直连商户
+ *
+ * @author felord.cn
+ * @since 1.0.16.RELEASE
+ */
+public class WechatMarketingPartnershipApi extends AbstractApi {
+    /**
+     * Instantiates a new Abstract api.
+     *
+     * @param wechatPayClient the wechat pay client
+     * @param tenantId        the tenant id
+     */
+    public WechatMarketingPartnershipApi(WechatPayClient wechatPayClient, String tenantId) {
+        super(wechatPayClient, tenantId);
+    }
+
+    /**
+     * 建立合作关系API
+     * <p>
+     * 该接口主要为商户提供营销资源的授权能力，可授权给其他商户或小程序，方便商户间的互利合作。
+     *
+     * @param params the params
+     * @return the wechat response entity
+     */
+    public WechatResponseEntity<ObjectNode> build(PartnershipParams params) {
+        WechatResponseEntity<ObjectNode> wechatResponseEntity = new WechatResponseEntity<>();
+        this.client().withType(WechatPayV3Type.MARKETING_PARTNERSHIPS_BUILD, params)
+                .function((type, partnershipParams) -> {
+                    URI uri = UriComponentsBuilder.fromHttpUrl(type.uri(WeChatServer.CHINA))
+                            .build()
+                            .toUri();
+                    String idempotencyKey = partnershipParams.getIdempotencyKey();
+                    partnershipParams.clearKey();
+                    HttpHeaders httpHeaders = new HttpHeaders();
+                    httpHeaders.add("Idempotency-Key", idempotencyKey);
+                    return Post(uri, partnershipParams, httpHeaders);
+                })
+                .consumer(wechatResponseEntity::convert)
+                .request();
+        return wechatResponseEntity;
+    }
+
+    /**
+     * 查询合作关系列表API
+     * <p>
+     * 该接口主要为商户提供合作关系列表的查询能力。
+     *
+     * @param params the params
+     * @return the wechat response entity
+     */
+    public WechatResponseEntity<ObjectNode> query(PartnershipQueryParams params) {
+        WechatResponseEntity<ObjectNode> wechatResponseEntity = new WechatResponseEntity<>();
+        this.client().withType(WechatPayV3Type.MARKETING_PARTNERSHIPS_GET, params)
+                .function((type, partnershipParams) -> {
+                    MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+                    Partner partner = params.getPartner();
+
+                    try {
+                        ObjectMapper mapper = this.getMapper();
+                        if (Objects.nonNull(partner)) {
+                            String partnerJson = mapper.writeValueAsString(partner);
+                            queryParams.add("partner", UriUtils.encode(partnerJson, StandardCharsets.UTF_8));
+                        }
+                        String authorizedDataJson = mapper.writeValueAsString(params.getAuthorizedData());
+
+                        queryParams.add("authorized_data", UriUtils.encode(authorizedDataJson, StandardCharsets.UTF_8));
+                    } catch (JsonProcessingException e) {
+                        throw new PayException(e);
+                    }
+                    Integer limit = params.getLimit();
+                    if (Objects.nonNull(limit)) {
+                        queryParams.add("limit", limit.toString());
+                    }
+                    Integer offset = params.getOffset();
+                    if (Objects.nonNull(offset)) {
+                        queryParams.add("offset", offset.toString());
+                    }
+                    URI uri = UriComponentsBuilder.fromHttpUrl(type.uri(WeChatServer.CHINA))
+                            .queryParams(queryParams)
+                            .build(false)
+                            .toUri();
+                    return Get(uri);
+                })
+                .consumer(wechatResponseEntity::convert)
+                .request();
+        return wechatResponseEntity;
+    }
+}

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMarketingPartnershipApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMarketingPartnershipApi.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019-2023 felord.cn
+ *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -93,7 +93,6 @@ public class WechatMarketingPartnershipApi extends AbstractApi {
                 .function((type, partnershipParams) -> {
                     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
                     Partner partner = params.getPartner();
-
                     try {
                         ObjectMapper mapper = this.getMapper();
                         if (Objects.nonNull(partner)) {

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMetaBean.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMetaBean.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMetaContainer.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMetaContainer.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMetaContainer.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatMetaContainer.java
@@ -18,6 +18,8 @@ package cn.felord.payment.wechat.v3;
 
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 /**
  * 配置容器
@@ -26,21 +28,25 @@ import java.util.*;
  * @since 1.0.0.RELEASE
  */
 public class WechatMetaContainer {
-    private final Map<String, WechatMetaBean> wechatMetaBeanMap = new HashMap<>();
-    private final Set<String> tenantIds = new HashSet<>();
+    private final Map<String, WechatMetaBean> wechatMetaBeanMap = new ConcurrentHashMap<>();
+    private final Set<String> tenantIds = new ConcurrentSkipListSet<>();
 
 
     /**
-     * Add wechat meta boolean.
+     * Add wechat metas.
      *
-     * @param tenantId       the tenantId
-     * @param wechatMetaBean the wechat meta bean
-     * @return the boolean
+     * @param wechatMetaBeans the wechat meta beans
      */
-    public WechatMetaBean addWechatMeta(String tenantId, WechatMetaBean wechatMetaBean) {
-        tenantIds.add(tenantId);
-        return this.wechatMetaBeanMap.put(tenantId, wechatMetaBean);
+    public void addWechatMetas(Collection<WechatMetaBean> wechatMetaBeans) {
+        wechatMetaBeans.forEach(this::addMeta);
     }
+
+    private void addMeta(WechatMetaBean wechatMetaBean) {
+        String tenantId = wechatMetaBean.getTenantId();
+        tenantIds.add(tenantId);
+        wechatMetaBeanMap.put(tenantId, wechatMetaBean);
+    }
+
 
     /**
      * Remove wechat meta wechat meta bean.

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatPayCallback.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatPayCallback.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatPayClient.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatPayClient.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatPayScoreApi.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatPayScoreApi.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatRequestEntity.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatRequestEntity.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatResponseEntity.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/WechatResponseEntity.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/AbstractPayParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/AbstractPayParams.java
@@ -23,6 +23,8 @@ import lombok.Data;
 import java.time.LocalDateTime;
 
 /**
+ * The type Abstract pay params.
+ *
  * @author felord.cn
  * @since 1.0.8.RELEASE
  */
@@ -68,6 +70,13 @@ public abstract class AbstractPayParams {
      * 支付者  JSAPI/小程序下单 必传
      */
     private Payer payer;
+    /**
+     * 电子发票入口开放标识
+     * <p>
+     * 传入{@code true}时，支付成功消息和支付详情页将出现开票入口。需要在微信支付商户平台或微信公众平台开通电子发票功能，传此字段才可生效。
+     * @since 1.0.16.RELEASE
+     */
+    private Boolean supportFapiao;
     /**
      * 场景信息
      */

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/Amount.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/Amount.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/CallbackParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/CallbackParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ConsumeInformation.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ConsumeInformation.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/CouponAvailableTime.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/CouponAvailableTime.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/CouponConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/CouponConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/CouponDetailsQueryParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/CouponDetailsQueryParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/CouponUseRule.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/CouponUseRule.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/Detail.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/Detail.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/DiscountTo.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/DiscountTo.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/FixAvailableTime.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/FixAvailableTime.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/FixedNormalCoupon.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/FixedNormalCoupon.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/FundFlowBillParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/FundFlowBillParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/Goods.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/Goods.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/GoodsDetail.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/GoodsDetail.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/H5Info.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/H5Info.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/MchQueryParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/MchQueryParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/NormalCouponInformation.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/NormalCouponInformation.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/PatternInfo.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/PatternInfo.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/PayParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/PayParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/Payer.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/Payer.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ProfitSharingConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ProfitSharingConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/PromotionDetail.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/PromotionDetail.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 package cn.felord.payment.wechat.v3.model;

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/RefundConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/RefundConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/RefundParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/RefundParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ResponseSignVerifyParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ResponseSignVerifyParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/SceneInfo.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/SceneInfo.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/SettleInfo.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/SettleInfo.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/SingleitemDiscountOff.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/SingleitemDiscountOff.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/StockUseRule.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/StockUseRule.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/StocksCreateParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/StocksCreateParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/StocksQueryParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/StocksQueryParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/StocksSendParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/StocksSendParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/StoreInfo.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/StoreInfo.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/TradeBillParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/TradeBillParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/TransactionConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/TransactionConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/TransactionQueryParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/TransactionQueryParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/UserCouponsQueryParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/UserCouponsQueryParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/batchtransfer/CreateBatchTransferParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/batchtransfer/CreateBatchTransferParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.batchtransfer;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/batchtransfer/CreateBatchTransferParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/batchtransfer/CreateBatchTransferParams.java
@@ -59,6 +59,10 @@ public class CreateBatchTransferParams {
      * 转账总笔数,一个转账批次单最多发起三千笔转账。转账总笔数必须与批次内所有明细之和保持一致，否则无法发起转账操作
      */
     private Integer totalNum;
+    /**
+     * 指定该笔转账使用的转账场景ID
+     */
+    private String transferSceneId;
 
     /**
      * 转账明细.

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/batchtransfer/QueryDayBalanceParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/batchtransfer/QueryDayBalanceParams.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package cn.felord.payment.wechat.v3.model.batchtransfer;
 
 import cn.felord.payment.wechat.enumeration.FundFlowAccountType;

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/batchtransfer/QueryIncomeRecordParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/batchtransfer/QueryIncomeRecordParams.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package cn.felord.payment.wechat.v3.model.batchtransfer;
 
 import cn.felord.payment.wechat.enumeration.FundFlowAccountType;

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/batchtransfer/TransferDetailElectronicParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/batchtransfer/TransferDetailElectronicParams.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package cn.felord.payment.wechat.v3.model.batchtransfer;
 
 import cn.felord.payment.wechat.enumeration.TransferAcceptType;

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombineAmount.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombineAmount.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.combine;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombineCloseParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombineCloseParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.combine;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombineH5PayParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombineH5PayParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.combine;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombineH5SceneInfo.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombineH5SceneInfo.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombinePayParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombinePayParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.combine;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombinePayerInfo.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombinePayerInfo.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.combine;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombineSceneInfo.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombineSceneInfo.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.combine;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombineTransactionConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/CombineTransactionConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/SubOrder.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/combine/SubOrder.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.combine;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/DiscountCardAcceptedConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/DiscountCardAcceptedConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/DiscountCardAgreementEndConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/DiscountCardAgreementEndConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/DiscountCardConsumer.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/DiscountCardConsumer.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/DiscountCardPreRequestParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/DiscountCardPreRequestParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.discountcard;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/DiscountCardUserPaidConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/DiscountCardUserPaidConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/ObjectiveCompletionRecord.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/ObjectiveCompletionRecord.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/RewardUsageRecord.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/RewardUsageRecord.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/UserRecordsParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/discountcard/UserRecordsParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ecommerce/EcommerceAccountInfo.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ecommerce/EcommerceAccountInfo.java
@@ -33,5 +33,6 @@ public class EcommerceAccountInfo {
 	private String bankBranchId;
 	private String bankName;
 	private String accountNumber;
+	@Deprecated
 	private AccountCertInfo accountCertInfo;
 }

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ecommerce/EcommerceErrorBillParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ecommerce/EcommerceErrorBillParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ecommerce/EcommerceFinishOrder.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ecommerce/EcommerceFinishOrder.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package cn.felord.payment.wechat.v3.model.ecommerce;
 
 import lombok.Data;

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ecommerce/EcommerceProfitsharingOrder.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ecommerce/EcommerceProfitsharingOrder.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package cn.felord.payment.wechat.v3.model.ecommerce;
 
 import lombok.Data;

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ecommerce/EcommerceSubsidiesCreateParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ecommerce/EcommerceSubsidiesCreateParams.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package cn.felord.payment.wechat.v3.model.ecommerce;
 
 import lombok.Data;

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ecommerce/Receiver.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/ecommerce/Receiver.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package cn.felord.payment.wechat.v3.model.ecommerce;
 
 import cn.felord.payment.wechat.enumeration.ReceiverType;

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/partnership/AuthorizedData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/partnership/AuthorizedData.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cn.felord.payment.wechat.v3.model.partnership;
+
+import cn.felord.payment.wechat.enumeration.BusinessType;
+import lombok.Data;
+
+/**
+ * @author felord.cn
+ * @since 1.0.16.RELEASE
+ */
+@Data
+public class AuthorizedData {
+    private final BusinessType businessType;
+    private final String stockId;
+}

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/partnership/Partner.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/partnership/Partner.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cn.felord.payment.wechat.v3.model.partnership;
+
+import cn.felord.payment.wechat.enumeration.PartnerType;
+import lombok.Getter;
+
+/**
+ * The type Partner.
+ *
+ * @author felord.cn
+ * @since 1.0.16.RELEASE
+ */
+@Getter
+public class Partner {
+    private final PartnerType type;
+    private final String appid;
+    private final String merchantId;
+
+    /**
+     * Instantiates a new Partner.
+     *
+     * @param type       the type
+     * @param appid      the appid
+     * @param merchantId the merchant id
+     */
+    Partner(PartnerType type, String appid, String merchantId) {
+        this.type = type;
+        this.appid = appid;
+        this.merchantId = merchantId;
+    }
+
+    /**
+     * 建立APP合作
+     *
+     * @param appid the appid
+     * @return the partner
+     */
+    public static Partner app(String appid) {
+        return new Partner(PartnerType.APPID, appid, null);
+    }
+
+    /**
+     * 建立商户合作
+     *
+     * @param merchantId the merchant id
+     * @return the partner
+     */
+    public static Partner merchant(String merchantId) {
+        return new Partner(PartnerType.MERCHANT, null, merchantId);
+    }
+}

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/partnership/PartnershipParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/partnership/PartnershipParams.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cn.felord.payment.wechat.v3.model.partnership;
+
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * @author felord.cn
+ * @since 1.0.16.RELEASE
+ */
+@ToString
+@Getter
+public class PartnershipParams {
+    private String idempotencyKey;
+    private final Partner partner;
+    private final AuthorizedData authorizedData;
+
+    public PartnershipParams(String idempotencyKey, Partner partner, AuthorizedData authorizedData) {
+        this.idempotencyKey = idempotencyKey;
+        this.partner = partner;
+        this.authorizedData = authorizedData;
+    }
+
+    public void clearKey() {
+        this.idempotencyKey = null;
+    }
+}

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/partnership/PartnershipQueryParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/partnership/PartnershipQueryParams.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2019-2022 felord.cn
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *  Website:
+ *       https://felord.cn
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cn.felord.payment.wechat.v3.model.partnership;
+
+import lombok.Data;
+
+/**
+ * @author felord.cn
+ * @since 1.0.16.RELEASE
+ */
+@Data
+public class PartnershipQueryParams {
+
+    private final Partner partner;
+    private final AuthorizedData authorizedData;
+    private Integer limit;
+    private Integer offset;
+
+    public PartnershipQueryParams(Partner partner, AuthorizedData authorizedData) {
+
+        this.partner = partner;
+        this.authorizedData = authorizedData;
+    }
+
+}

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/CancelServiceOrderParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/CancelServiceOrderParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/CompleteServiceOrderParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/CompleteServiceOrderParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/DirectCompleteServiceOrderParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/DirectCompleteServiceOrderParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/Location.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/Location.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/ModifyServiceOrderParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/ModifyServiceOrderParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PayScoreConsumer.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PayScoreConsumer.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PayScoreUserConfirmConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PayScoreUserConfirmConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PayScoreUserPaidConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PayScoreUserPaidConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PayScoreUserPermissionConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PayScoreUserPermissionConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PayServiceOrderParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PayServiceOrderParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PaymentCollection.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PaymentCollection.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PermissionsAuthCodeParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PermissionsAuthCodeParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PermissionsOpenIdParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PermissionsOpenIdParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PostDiscount.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PostDiscount.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PostPayment.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PostPayment.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PromotionDetail.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/PromotionDetail.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/QueryServiceOrderParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/QueryServiceOrderParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/RiskFund.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/RiskFund.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/ServiceOrderPermissionParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/ServiceOrderPermissionParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/SyncServiceOrderParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/SyncServiceOrderParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/TimeRange.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/TimeRange.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/UserServiceOrderParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/UserServiceOrderParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/UserServiceStateParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/payscore/UserServiceStateParams.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.payscore;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/profitsharing/PartnerProfitsharingConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/profitsharing/PartnerProfitsharingConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.profitsharing;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/profitsharing/ProfitsharingConsumeData.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/profitsharing/ProfitsharingConsumeData.java
@@ -1,5 +1,4 @@
 /*
- *
  *  Copyright 2019-2022 felord.cn
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 package cn.felord.payment.wechat.v3.model.profitsharing;
 

--- a/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/specmch/ApplymentParams.java
+++ b/payment-spring-boot-autoconfigure/src/main/java/cn/felord/payment/wechat/v3/model/specmch/ApplymentParams.java
@@ -9,5 +9,6 @@ public class ApplymentParams {
 	private SubjectInfo subjectInfo;
 	private BusinessInfo businessInfo;
 	private SettlementInfo settlementInfo;
+	@Deprecated
 	private BankAccountInfo bankAccountInfo;
 }


### PR DESCRIPTION
## 微信支付
- feat: 直连商户-委托营销相关API实现
- enhance:基础支付增加电子发票入口开放标识
- enhance:商家转账到零钱-发起商家转账 增加转账场景ID
- enhance: 增加抽象接口`WechatTenantService`负责从配置文件或者其它数据源检索租户配置信息，提供默认实现`InMemoryWechatTenantService`向下兼容 #88  
- refactor: 服务商商户进件请求不再需要银行证明材料信息`BankAccountInfo`，已标记为废弃，涉及特约商户进件和电商收付通

